### PR TITLE
Trim RocksDB default codec dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,9 +2396,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
- "lz4-sys",
  "tikv-jemalloc-sys",
- "zstd-sys",
 ]
 
 [[package]]
@@ -2439,16 +2437,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "maestro-symphony"
@@ -6174,13 +6162,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 thiserror = "2.0.18"
 tempfile = "3.27.0"
-rocksdb = { version = "0.23.0", features = ["jemalloc"] }
+rocksdb = { version = "0.23.0", default-features = false, features = ["bindgen-runtime", "jemalloc", "snappy"] }
 gasket = { version = "0.9.0", features = ["derive"] }
 tokio = { version = "1.50.0", features = [
     "rt",


### PR DESCRIPTION
## Summary
- disable default `rocksdb` features and keep only `bindgen-runtime`, `jemalloc`, and `snappy`
- remove unused native codec dependencies from the lockfile (`lz4-sys`, `zstd-sys`)
- keep the change scoped to build-surface reduction with no runtime code changes

## Build Timing
Cold builds were measured with fresh `/tmp` target dirs:
- baseline: 761885 ms (12m 41.885s)
- optimized: 747409 ms (12m 27.409s)
- improvement: 14476 ms (14.476s, ~1.9%)

## Validation
- `cargo build --offline --quiet --target-dir /tmp/maestro-symphony-target-optimized-20260402a`
- `cargo test --offline --quiet --target-dir /tmp/maestro-symphony-target-optimized-20260402a`
- `/tmp/maestro-symphony-target-optimized-20260402a/debug/maestro-symphony --help`

## Notes
- the repo currently has no Rust tests, so `cargo test` completed with 0 tests
- the main remaining cold-build cost is still bundled RocksDB C++ plus bindgen